### PR TITLE
Add requiresMainQueueSetup

### DIFF
--- a/ios/EspSmartconfig.mm
+++ b/ios/EspSmartconfig.mm
@@ -215,7 +215,10 @@ RCT_EXPORT_METHOD(getWifiInfo:(RCTPromiseResolveBlock)resolve
     freeifaddrs(interfaces);
     return address;
 
-} 
+}
 
++ (BOOL) requiresMainQueueSetup { 
+    return YES; 
+}
 
 @end


### PR DESCRIPTION
Suppresses the following warning:
```
Module EspSmartconfig requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of. 
```